### PR TITLE
DateOrTimeObject doesn't have DISPLAY_FORMAT constant

### DIFF
--- a/src/Renderer/Chart/GraphChartRenderer.php
+++ b/src/Renderer/Chart/GraphChartRenderer.php
@@ -132,7 +132,7 @@ class GraphChartRenderer extends ChartRenderer
         }
 
         if ($value instanceof DateOrTimeObject) {
-            return $value->format($value::DISPLAY_FORMAT);
+            return $value->format(DateTime::DISPLAY_FORMAT);
         }
 
         return (string)$value;


### PR DESCRIPTION
I was running phpstan and noticed the error reported.

```
 ------ ---------------------------------------------------------------------------------------------- 
  Line   src/Renderer/Chart/GraphChartRenderer.php                                                     
 ------ ---------------------------------------------------------------------------------------------- 
  135    Access to undefined constant Dms\Common\Structure\DateTime\DateOrTimeObject::DISPLAY_FORMAT.  
 ------ ----------------------------------------------------------------------------------------------
```